### PR TITLE
Allow specifying a nonce for CSP

### DIFF
--- a/resources/views/tags.blade.php
+++ b/resources/views/tags.blade.php
@@ -1,15 +1,16 @@
 @foreach ($preloadedModules as $preloadedModule)
-    <link rel="modulepreload" href="{{ $preloadedModule }}">
+    <link rel="modulepreload" href="{{ $preloadedModule }}"@if ($nonce) nonce="{{ $nonce }}"@endif />
 @endforeach
 
 @if (config('importmap.use_shim'))
-<script async src="https://ga.jspm.io/npm:es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+@if ($nonce) <script type="esms-options" nonce="{{ $nonce }}">{"nonce":"{{ $nonce }}"}</script> @endif
+<script async src="https://ga.jspm.io/npm:es-module-shims@1.3.6/dist/es-module-shims.js" data-turbo-track="reload"@if ($nonce) nonce="{{ $nonce }}"@endif></script>
 @endif
 
-<script type="importmap">
+<script type="importmap" data-turbo-track="reload"@if ($nonce) nonce="{{ $nonce }}" @endif>
 @json($importmaps)
 </script>
 
-<script type="module">
-    import '{{ $entrypoint }}';
+<script type="module" data-turbo-track="reload"@if ($nonce) nonce="{{ $nonce }}" @endif>
+    import {{ $entrypoint }} as '{{ $entrypoint }}';
 </script>

--- a/src/View/Components/Tags.php
+++ b/src/View/Components/Tags.php
@@ -8,7 +8,7 @@ use Tonysm\ImportmapLaravel\Facades\Importmap;
 
 class Tags extends Component
 {
-    public function __construct(public string $entrypoint = 'app')
+    public function __construct(public string $entrypoint = 'app', public ?string $nonce = null)
     {
     }
 

--- a/tests/TagsComponentTest.php
+++ b/tests/TagsComponentTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+use Illuminate\Support\Facades\File;
+use Tonysm\ImportmapLaravel\Importmap;
+
+uses(InteractsWithViews::class);
+
+beforeEach(function () {
+    $this->map = $this->instance(Importmap::class, new Importmap($this->rootPath = __DIR__ . '/stubs'));
+
+    $this->map->pin("app");
+    $this->map->pin("md5", to: "https://cdn.skypack.dev/md5", preload: true);
+
+    if (File::isDirectory($this->distPath = $this->rootPath . '/public/dist/')) {
+        File::cleanDirectory($this->distPath);
+    }
+
+    $this->swap(Importmap::class, $this->map);
+});
+
+it('generates tags without nonce', function () {
+    $this->blade('<x-importmap-tags />')
+        ->assertSee('<link rel="modulepreload" href="https://cdn.skypack.dev/md5" />', escape: false)
+        ->assertDontSee('<script type="esms-options"', escape: false)
+        ->assertSee('<script async src="https://ga.jspm.io/npm:es-module-shims@1.3.6/dist/es-module-shims.js" data-turbo-track="reload"></script>', escape: false);
+});
+
+it('uses given CSP nonce', function () {
+    $this->blade('<x-importmap-tags nonce="h3ll0" />')
+        ->assertSee('<link rel="modulepreload" href="https://cdn.skypack.dev/md5" nonce="h3ll0" />', escape: false)
+        ->assertSee('<script type="esms-options" nonce="h3ll0">{"nonce":"h3ll0"}</script>', escape: false)
+        ->assertSee('<script async src="https://ga.jspm.io/npm:es-module-shims@1.3.6/dist/es-module-shims.js" data-turbo-track="reload" nonce="h3ll0"></script>', escape: false);
+});

--- a/tests/TagsComponentTest.php
+++ b/tests/TagsComponentTest.php
@@ -15,8 +15,6 @@ beforeEach(function () {
     if (File::isDirectory($this->distPath = $this->rootPath . '/public/dist/')) {
         File::cleanDirectory($this->distPath);
     }
-
-    $this->swap(Importmap::class, $this->map);
 });
 
 it('generates tags without nonce', function () {


### PR DESCRIPTION
### Added

- Adds a `data-turbo-track="reload"` to all links and script tags (useful when building apps with Turbo. Shouldn't affect non-Turbo users)
- Adds the ability to define a `nonce` which is useful when dealing with CSP ([read here](https://content-security-policy.com/nonce/)). This does not set your CSP `script-src`. Generating that and the nonce value itself (which should be cryptographically secure) is also outside the scope of the package and should be handled in app-land. What matters here is that you use the same nonce in your `script-src` CSP tag and pass that down to the `<x-importmap-tags nonce="{{ $nonce }}" />` component.