### PR TITLE
Wrap regex contact with preg_quote

### DIFF
--- a/src/Commands/PinCommand.php
+++ b/src/Commands/PinCommand.php
@@ -94,7 +94,7 @@ class PinCommand extends Command
     {
         return sprintf(
             '#^Importmap::pin\("%s".*$#',
-            $package,
+            preg_quote($package),
         );
     }
 }

--- a/src/Packager.php
+++ b/src/Packager.php
@@ -60,7 +60,7 @@ class Packager
     public function packaged(string $package): bool
     {
         return (bool) preg_match(
-            sprintf('#Importmap::pin\("%s"#', str_replace('#', '\#', $package)),
+            sprintf('#Importmap::pin\("%s"#', preg_quote($package)),
             File::get(base_path($this->importmapPath)),
         );
     }
@@ -86,7 +86,7 @@ class Packager
     {
         $contents = collect(File::lines(base_path($this->importmapPath)))
             ->reject(fn (string $line) => (
-                preg_match(sprintf('#Importmap::pin\("%s"#', $package), $line)
+                preg_match(sprintf('#Importmap::pin\("%s"#', preg_quote($package)), $line)
             ))
             ->join(PHP_EOL);
 


### PR DESCRIPTION
### Fixed

- Some package names were breaking the `importman:pin` command because the strings were being considered as part of the regex. We need to wrap the strings with `preg_quote` whenever we're contacting user-given strings into a regex.