### PR TITLE
Push symlinks config to package

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,23 +56,9 @@ By default the `x-importmap-tags` component assumes your entrypoint module is `a
 <x-importmap-tags entrypoint="admin" />
 ```
 
-We also need to symlink the `resources/js` folder to `public/js` to make our JavaScript files publicly available. It's recommended to do that only for local development. This can be achieved by adding the link rule to your `config/filesystems.php`:
+The package will automatically map the `resources/js` folder to your `public/js` folder using Laravel's symlink feature. All you have to do is run `php artisan storage:link` after installing the package. If you're using Laravel Sail, make sure you prefix that command with `sail` as the symlink needs to be created inside the container.
 
-```php
-<?php
-
-return [
-    // ...
-    'links' => array_filter([
-        public_path('storage') => storage_path('app/public'),
-        public_path('js') => env('APP_ENV') === 'local' ? resource_path('js') : null,
-    ]),
-];
-```
-
-Now, whenever you run `php artisan storage:link` in the `local` env, your `resources/js` folder will be linked to the `public/js` folder, which will make your imports work while you're developing your app.
-
-For production, it's recommended to run the `importmap:optimize` command instead:
+The symlink is only register on local environments. For production, it's recommended to run the `importmap:optimize` command instead:
 
 ```php
 php artisan importmap:optimize

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -27,7 +27,6 @@ class InstallCommand extends Command
         $this->importDependenciesFromNpm();
         $this->updateAppLayouts();
         $this->deleteNpmRelatedFiles();
-        $this->configureJsSymlink();
         $this->configureIgnoredFolder();
 
         $this->displayAfterNotes();
@@ -193,37 +192,6 @@ class InstallCommand extends Command
         return collect(['app', 'guest'])
             ->map(fn ($file) => resource_path("views/layouts/{$file}.blade.php"))
             ->filter(fn ($file) => File::exists($file));
-    }
-
-    private function configureJsSymlink()
-    {
-        $this->displayTask('configuring JS symlink', function () {
-            File::put(
-                $configFile = base_path('config/filesystems.php'),
-                preg_replace(
-                    '/(\s*)\'links\' => \[((?:.|\n)*)(?:],)+?/',
-                    "\\1'links' => array_filter([\n\\1    public_path('js') => env('APP_ENV') === 'local' ? resource_path('js') : null,\\2]),",
-                    File::get($configFile),
-                ),
-            );
-
-            File::put(
-                $configFile,
-                preg_replace(
-                    '/(array_filter\(\[)\n\n/',
-                    '\\1',
-                    File::get($configFile),
-                ),
-            );
-
-            if (File::isDirectory(public_path('js'))) {
-                $this->afterMessages[] = "<fg=white>* Please, delete the `<fg=yellow>public/js</>` folder before the next step.</>\n";
-            }
-
-            $this->afterMessages[] = "<fg=white>* To create the symlink, run:</>\n\n\n    <fg=yellow>    php artisan storage:link</>\n";
-
-            return self::SUCCESS;
-        });
     }
 
     private function displayHeader($text, $prefix)

--- a/src/ImportmapLaravelServiceProvider.php
+++ b/src/ImportmapLaravelServiceProvider.php
@@ -45,5 +45,11 @@ class ImportmapLaravelServiceProvider extends PackageServiceProvider
         if (file_exists(base_path('routes/importmap.php'))) {
             require base_path('routes/importmap.php');
         }
+
+        if (app()->environment('local') && app()->runningInConsole()) {
+            config()->set('filesystems.links', config('filesystems.links') + [
+                public_path('js') => resource_path('js'),
+            ]);
+        }
     }
 }


### PR DESCRIPTION
### Changed

- Instead of patching the application to add the symlink line, we can add the JS path to the `filesystems.links` at runtime in the package's ServiceProvider.

---

closes https://github.com/tonysm/importmap-laravel/issues/28