### PR TITLE
Adds a `bin/importmap` script

### DIFF
--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+ARGS=(php artisan)
+
+if [ $# -gt 0 ]; then
+    ARGS+=("importmap:$@")
+else
+    ARGS+=(list importmap)
+fi
+
+"${ARGS[@]}"

--- a/bin/importmap
+++ b/bin/importmap
@@ -8,4 +8,7 @@ else
     ARGS+=(list importmap)
 fi
 
-"${ARGS[@]}"
+OUTPUT=$("${ARGS[@]}")
+MODIFIED_OUTPUT="${OUTPUT//importmap:/importmap }"
+
+echo $MODIFIED_OUTPUT

--- a/bin/importmap
+++ b/bin/importmap
@@ -11,4 +11,4 @@ fi
 OUTPUT=$("${ARGS[@]}")
 MODIFIED_OUTPUT="${OUTPUT//importmap:/importmap }"
 
-echo $MODIFIED_OUTPUT
+echo "${MODIFIED_OUTPUT}"

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5"
     },
+    "bin": [
+        "bin/importmap"
+    ],
     "autoload": {
         "psr-4": {
             "Tonysm\\ImportmapLaravel\\": "src"


### PR DESCRIPTION
### Added

- Adds a `bin/importmap` BASH Script that forwards the calls to the `artisan importmap:*` commands. This is a bit better as we only have to do `importmap pin @hotwired/stimulus` instead of `php artisan importmap:pin @hotwired/stimulus`. It also works with Sail via `sail bin importmap pin @hotwired/stimulus`

---

It's currently losing colors, but I think that's okay.

closes https://github.com/tonysm/importmap-laravel/issues/31