### PR TITLE
Fix installation script not properly fixing paths resolution

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,6 +46,4 @@ jobs:
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: |
-          chmod -R ug+rw tests/tmp
-          vendor/bin/phpunit
+        run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -49,3 +49,14 @@ jobs:
         run: |
           chmod -R ug+rw tests/tmp
           vendor/bin/phpunit
+        continue-on-error: true
+
+      - name: Zip Folder
+        run: zip -r tests-tmp.zip tests/tmp
+
+      - name: Upload Artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: tests-tmp-folder
+          path: tests-tmp.zip

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,4 +46,6 @@ jobs:
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/phpunit
+        run: |
+          chmod -R ug+rw tests/tmp
+          vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -49,14 +49,3 @@ jobs:
         run: |
           chmod -R ug+rw tests/tmp
           vendor/bin/phpunit
-        continue-on-error: true
-
-      - name: Zip Folder
-        run: zip -r tests-tmp.zip tests/tmp
-
-      - name: Upload Artifacts
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: tests-tmp-folder
-          path: tests-tmp.zip

--- a/src/Actions/FixJsImportPaths.php
+++ b/src/Actions/FixJsImportPaths.php
@@ -33,7 +33,7 @@ class FixJsImportPaths
 
     private function absoluteOutputPathWithFileFor(SplFileInfo $file)
     {
-        return rtrim($this->absoluteOutputPathFor($file), '/').'/'.$file->getFilename();
+        return rtrim($this->absoluteOutputPathFor($file), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$file->getFilename();
     }
 
     private function updatedJsImports(SplFileInfo $file)
@@ -51,9 +51,9 @@ class FixJsImportPaths
                     function ($matches) use ($file) {
                         $replaced = $this->replaceDotImports($file, $matches[1], $matches[0]);
 
-                        $relative = trim(str_replace($this->root, '', $replaced), '/');
+                        $relative = trim(str_replace($this->root, '', $replaced), DIRECTORY_SEPARATOR);
 
-                        return str_replace($matches[1], $relative, $matches[0]);
+                        return str_replace(DIRECTORY_SEPARATOR, '/', str_replace($matches[1], $relative, $matches[0]));
                     },
                     $line,
                 );
@@ -69,13 +69,13 @@ class FixJsImportPaths
     {
         $removeExtension = false;
         $removeIndex = false;
-        $path = rtrim($file->getPath(), '/').'/'.$imports;
+        $path = rtrim($file->getPath(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $imports);
 
         if (is_dir($path)) {
             $removeIndex = true;
-            $path = File::exists(rtrim($path, '/').'/index.mjs')
-                ? rtrim($path, '/').'/index.mjs'
-                : rtrim($path, '/').'/index.js';
+            $path = File::exists(implode(DIRECTORY_SEPARATOR, [rtrim($path, DIRECTORY_SEPARATOR), 'index.mjs']))
+                ? rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'index.mjs'
+                : rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'index.js';
         }
 
         if (! str_ends_with($path, '.js') && ! str_ends_with($path, '.mjs')) {
@@ -90,7 +90,7 @@ class FixJsImportPaths
         }
 
         if ($removeIndex) {
-            return Str::beforeLast($fixedPath, '/');
+            return Str::beforeLast($fixedPath, DIRECTORY_SEPARATOR);
         }
 
         if ($removeExtension) {

--- a/src/Actions/FixJsImportPaths.php
+++ b/src/Actions/FixJsImportPaths.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tonysm\ImportmapLaravel\Actions;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use SplFileInfo;
+use Tonysm\ImportmapLaravel\Exceptions\FailedToFixImportStatementException;
+
+class FixJsImportPaths
+{
+    public function __construct(public string $root, public ?string $output = null)
+    {
+        $this->output ??= $root;
+    }
+
+    public function __invoke()
+    {
+        collect(File::allFiles($this->root))
+            ->filter(fn (SplFileInfo $file) => in_array($file->getExtension(), ['js', 'mjs']))
+            ->each(fn (SplFileInfo $file) => File::ensureDirectoryExists($this->absoluteOutputPathFor($file)))
+            ->each(fn (SplFileInfo $file) => File::put(
+                $this->absoluteOutputPathWithFileFor($file),
+                $this->updatedJsImports($file),
+            ));
+    }
+
+    private function absoluteOutputPathFor(SplFileInfo $file)
+    {
+        return str_replace($this->root, $this->output, dirname($file->getRealPath()));
+    }
+
+    private function absoluteOutputPathWithFileFor(SplFileInfo $file)
+    {
+        return rtrim($this->absoluteOutputPathFor($file), '/').'/'.$file->getFilename();
+    }
+
+    private function updatedJsImports(SplFileInfo $file)
+    {
+        $lines = File::lines($file->getRealPath())->all();
+
+        foreach ($lines as $index => $line) {
+            if (! str_starts_with($line, 'import ')) {
+                continue;
+            }
+
+            $lines[$index] = preg_replace_callback(
+                '#import (?:.*["\'])(\..*)(?:[\'"];?.*)#',
+                function ($matches) use ($file) {
+                    $replaced = $this->replaceDotImports($file->getPath(), $matches[1]);
+
+                    if (! $replaced) {
+                        throw FailedToFixImportStatementException::couldNotFixImport($matches[0], $file);
+                    }
+
+                    $relative = trim(str_replace($this->root, '', $replaced), '/');
+
+                    return str_replace($matches[1], $relative, $matches[0]);
+                },
+                $line,
+            );
+        }
+
+        return implode(PHP_EOL, $lines);
+    }
+
+    private function replaceDotImports(string $path, string $imports)
+    {
+        $removeExtension = false;
+        $removeIndex = false;
+        $path = rtrim($path, '/').'/'.$imports;
+
+        if (is_dir($path)) {
+            $removeIndex = true;
+            $path = File::exists(rtrim($path, '/').'/index.mjs')
+                ? rtrim($path, '/').'/index.mjs'
+                : rtrim($path, '/').'/index.js';
+        }
+
+        if (! str_ends_with($path, '.js') && ! str_ends_with($path, '.mjs')) {
+            $removeExtension = true;
+            $path = File::exists($path.'.mjs')
+                ? $path.'.mjs'
+                : $path.'.js';
+        }
+
+        if (! ($fixedPath = realpath($path))) {
+            return false;
+        }
+
+        if ($removeIndex) {
+            return Str::beforeLast($fixedPath, '/');
+        }
+
+        if ($removeExtension) {
+            return Str::beforeLast($fixedPath, '.');
+        }
+
+        return $fixedPath;
+    }
+}

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Terminal;
 use Tonysm\ImportmapLaravel\Actions\FixJsImportPaths;
 use Tonysm\ImportmapLaravel\Events\FailedToFixImportStatement;
@@ -62,7 +63,7 @@ class InstallCommand extends Command
     private function publishImportmapFile(): void
     {
         $this->displayTask('publishing the `routes/importmap.php` file', function () {
-            File::copy(__DIR__.'/../../stubs/routes/importmap.php', base_path('routes/importmap.php'));
+            File::copy(dirname(__DIR__, 2).join(DIRECTORY_SEPARATOR, ['', 'stubs', 'routes', 'importmap.php']), base_path(join(DIRECTORY_SEPARATOR, ['routes', 'importmap.php'])));
 
             return self::SUCCESS;
         });
@@ -79,7 +80,7 @@ class InstallCommand extends Command
         });
 
         $this->displayTask('converting js imports', function () {
-            $root = rtrim(resource_path('js'), '/').'/';
+            $root = rtrim(resource_path('js'), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
 
             (new FixJsImportPaths($root))();
 
@@ -224,6 +225,10 @@ class InstallCommand extends Command
 
     private function configureIgnoredFolder()
     {
+        if (Str::contains(File::get(base_path('.gitignore')), 'public/js')) {
+            return;
+        }
+
         $this->displayTask('dumping & ignoring `public/js` folder', function () {
             File::append(
                 base_path('.gitignore'),

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -5,8 +5,8 @@ namespace Tonysm\ImportmapLaravel\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
-use SplFileInfo;
 use Symfony\Component\Console\Terminal;
+use Tonysm\ImportmapLaravel\Actions\FixJsImportPaths;
 
 class InstallCommand extends Command
 {
@@ -69,16 +69,9 @@ class InstallCommand extends Command
     private function convertLocalImportsFromUsingDots(): void
     {
         $this->displayTask('converting js imports', function () {
-            collect(File::allFiles(resource_path('js')))
-                ->filter(fn (SplFileInfo $file) => in_array($file->getExtension(), ['js', 'mjs']))
-                ->each(fn (SplFileInfo $file) => File::put(
-                    $file->getRealPath(),
-                    preg_replace(
-                        "/import (.*['\"])\.\/(.*)/",
-                        'import $1$2',
-                        File::get($file->getRealPath()),
-                    ),
-                ));
+            $root = rtrim(resource_path('js'), '/').'/';
+
+            (new FixJsImportPaths($root))();
 
             return self::SUCCESS;
         });

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -4,9 +4,11 @@ namespace Tonysm\ImportmapLaravel\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Symfony\Component\Console\Terminal;
 use Tonysm\ImportmapLaravel\Actions\FixJsImportPaths;
+use Tonysm\ImportmapLaravel\Events\FailedToFixImportStatement;
 
 class InstallCommand extends Command
 {
@@ -68,6 +70,14 @@ class InstallCommand extends Command
 
     private function convertLocalImportsFromUsingDots(): void
     {
+        Event::listen(function (FailedToFixImportStatement $event) {
+            $this->afterMessages[] = sprintf(
+                'Failed to fix import statement (%s) in file (%).',
+                $event->importStatement,
+                str_replace(base_path(), '', $event->file->getPath()),
+            );
+        });
+
         $this->displayTask('converting js imports', function () {
             $root = rtrim(resource_path('js'), '/').'/';
 

--- a/src/Events/FailedToUpdateImportStatement.php
+++ b/src/Events/FailedToUpdateImportStatement.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tonysm\ImportmapLaravel\Events;
+
+use SplFileInfo;
+
+class FailedToFixImportStatement
+{
+    public function __construct(public SplFileInfo $file, public string $importStatement)
+    {
+        //
+    }
+}

--- a/src/Exceptions/FailedToFixImportStatementException.php
+++ b/src/Exceptions/FailedToFixImportStatementException.php
@@ -6,19 +6,19 @@ use SplFileInfo;
 
 class FailedToFixImportStatementException extends ImportmapException
 {
-    public string $line;
+    public string $importStatement;
 
     public SplFileInfo $file;
 
-    public static function couldNotFixImport(string $line, SplFileInfo $file)
+    public static function couldNotFixImport(string $importStatement, SplFileInfo $file)
     {
         $exception = new static(sprintf(
             'Failed to fix import statement (%s) in file (%s)',
-            $line,
+            $importStatement,
             trim(str_replace(base_path(), '', $file->getPath()), '/')
         ));
 
-        $exception->line = $line;
+        $exception->importStatement = $importStatement;
         $exception->file = $file;
 
         return $exception;

--- a/src/Exceptions/FailedToFixImportStatementException.php
+++ b/src/Exceptions/FailedToFixImportStatementException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tonysm\ImportmapLaravel\Exceptions;
+
+use SplFileInfo;
+
+class FailedToFixImportStatementException extends ImportmapException
+{
+    public string $line;
+
+    public SplFileInfo $file;
+
+    public static function couldNotFixImport(string $line, SplFileInfo $file)
+    {
+        $exception = new static(sprintf(
+            'Failed to fix import statement (%s) in file (%s)',
+            $line,
+            trim(str_replace(base_path(), '', $file->getPath()), '/')
+        ));
+
+        $exception->line = $line;
+        $exception->file = $file;
+
+        return $exception;
+    }
+}

--- a/src/Importmap.php
+++ b/src/Importmap.php
@@ -20,12 +20,12 @@ class Importmap
         $this->directories = collect();
     }
 
-    public function pin(string $name, ?string $to = null, bool $preload = false)
+    public function pin(string $name, string $to = null, bool $preload = false)
     {
         $this->packages->add(new MappedFile($name, path: $to ?: "js/{$name}.js", preload: $preload));
     }
 
-    public function pinAllFrom(string $dir, ?string $under = null, ?string $to = null, bool $preload = false)
+    public function pinAllFrom(string $dir, string $under = null, string $to = null, bool $preload = false)
     {
         $this->directories->add(new MappedDirectory($dir, $under, $to, $preload));
     }

--- a/tests/FixJsImportPathsTest.php
+++ b/tests/FixJsImportPathsTest.php
@@ -19,10 +19,10 @@ class FixJsImportPathsTest extends TestCase
         parent::setUp();
 
         $folder = (string) Str::uuid();
-        File::ensureDirectoryExists($this->tmpFolder = __DIR__.'/tmp/fixing-paths/'.$folder);
+        File::ensureDirectoryExists($this->tmpFolder = __DIR__.implode(DIRECTORY_SEPARATOR, ['', 'tmp', 'fixing-paths', $folder]));
         File::cleanDirectory(dirname($this->tmpFolder));
 
-        $this->action = new FixJsImportPaths(root: $this->rootFolder = __DIR__.'/stubs/fixing-paths', output: $this->tmpFolder);
+        $this->action = new FixJsImportPaths(root: $this->rootFolder = __DIR__.implode(DIRECTORY_SEPARATOR, ['', 'stubs', 'fixing-paths']), output: $this->tmpFolder);
     }
 
     /** @test */
@@ -31,19 +31,19 @@ class FixJsImportPathsTest extends TestCase
         $this->action->__invoke();
 
         // Root files...
-        $this->assertTrue(File::exists($this->tmpFolder.'/app.js'));
-        $this->assertMatchesRegularExpression('#import ["\']bootstrap["\']#', File::get($this->tmpFolder.'/app.js'));
-        $this->assertMatchesRegularExpression('#import axios from ["\']axios["\']#', File::get($this->tmpFolder.'/bootstrap.js'));
+        $this->assertTrue(File::exists($this->tmpFolder.DIRECTORY_SEPARATOR.'app.js'));
+        $this->assertMatchesRegularExpression('#import ["\']bootstrap["\']#', File::get($this->tmpFolder.DIRECTORY_SEPARATOR.'app.js'));
+        $this->assertMatchesRegularExpression('#import axios from ["\']axios["\']#', File::get($this->tmpFolder.DIRECTORY_SEPARATOR.'bootstrap.js'));
 
         // Libs folders...
-        $this->assertMatchesRegularExpression('#import ["\']libs/turbo["\']#', File::get($this->tmpFolder.'/libs/index.js'));
-        $this->assertMatchesRegularExpression('#import ["\']controllers["\']#', File::get($this->tmpFolder.'/libs/index.js'));
-        $this->assertFileEquals($this->tmpFolder.'/libs/stimulus.js', $this->rootFolder.'/libs/stimulus.js');
-        $this->assertFileEquals($this->tmpFolder.'/libs/turbo.js', $this->rootFolder.'/libs/turbo.js');
+        $this->assertMatchesRegularExpression('#import ["\']libs/turbo["\']#', File::get($this->tmpFolder.implode(DIRECTORY_SEPARATOR, ['', 'libs', 'index.js'])));
+        $this->assertMatchesRegularExpression('#import ["\']controllers["\']#', File::get($this->tmpFolder.implode(DIRECTORY_SEPARATOR, ['', 'libs', 'index.js'])));
+        $this->assertFileEquals($this->tmpFolder.implode(DIRECTORY_SEPARATOR, ['', 'libs', 'stimulus.js']), $this->rootFolder.implode(DIRECTORY_SEPARATOR, ['', 'libs', 'stimulus.js']));
+        $this->assertFileEquals($this->tmpFolder.implode(DIRECTORY_SEPARATOR, ['', 'libs', 'turbo.js']), $this->rootFolder.implode(DIRECTORY_SEPARATOR, ['', 'libs', 'turbo.js']));
 
         // Controllers folder...
-        $this->assertMatchesRegularExpression('#import { application } from ["\']libs/stimulus["\']#', File::get($this->tmpFolder.'/controllers/index.js'));
-        $this->assertMatchesRegularExpression('#import hello from ["\']controllers/hello_controller["\']#', File::get($this->tmpFolder.'/controllers/index.js'));
-        $this->assertMatchesRegularExpression('#import { Controller } from ["\']@hotwired/stimulus["\']#', File::get($this->tmpFolder.'/controllers/hello_controller.js'));
+        $this->assertMatchesRegularExpression('#import { application } from ["\']libs/stimulus["\']#', File::get($this->tmpFolder.implode(DIRECTORY_SEPARATOR, ['', 'controllers', 'index.js'])));
+        $this->assertMatchesRegularExpression('#import hello from ["\']controllers/hello_controller["\']#', File::get($this->tmpFolder.implode(DIRECTORY_SEPARATOR, ['', 'controllers', 'index.js'])));
+        $this->assertMatchesRegularExpression('#import { Controller } from ["\']@hotwired/stimulus["\']#', File::get($this->tmpFolder.implode(DIRECTORY_SEPARATOR, ['', 'controllers', 'hello_controller.js'])));
     }
 }

--- a/tests/FixJsImportPathsTest.php
+++ b/tests/FixJsImportPathsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tonysm\ImportmapLaravel\Tests;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tonysm\ImportmapLaravel\Actions\FixJsImportPaths;
+
+class FixJsImportPathsTest extends TestCase
+{
+    protected string $tmpFolder;
+
+    protected string $rootFolder;
+
+    protected FixJsImportPaths $action;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $folder = (string) Str::uuid();
+        File::ensureDirectoryExists($this->tmpFolder = __DIR__.'/tmp/fixing-paths/'.$folder);
+        File::cleanDirectory(dirname($this->tmpFolder));
+
+        $this->action = new FixJsImportPaths(root: $this->rootFolder = __DIR__.'/stubs/fixing-paths', output: $this->tmpFolder);
+    }
+
+    /** @test */
+    public function fixes_imports()
+    {
+        $this->action->__invoke();
+
+        // Root files...
+        $this->assertTrue(File::exists($this->tmpFolder.'/app.js'));
+        $this->assertMatchesRegularExpression('#import ["\']bootstrap["\']#', File::get($this->tmpFolder.'/app.js'));
+        $this->assertMatchesRegularExpression('#import axios from ["\']axios["\']#', File::get($this->tmpFolder.'/bootstrap.js'));
+
+        // Libs folders...
+        $this->assertMatchesRegularExpression('#import ["\']libs/turbo["\']#', File::get($this->tmpFolder.'/libs/index.js'));
+        $this->assertMatchesRegularExpression('#import ["\']controllers["\']#', File::get($this->tmpFolder.'/libs/index.js'));
+        $this->assertFileEquals($this->tmpFolder.'/libs/stimulus.js', $this->rootFolder.'/libs/stimulus.js');
+        $this->assertFileEquals($this->tmpFolder.'/libs/turbo.js', $this->rootFolder.'/libs/turbo.js');
+
+        // Controllers folder...
+        $this->assertMatchesRegularExpression('#import { application } from ["\']libs/stimulus["\']#', File::get($this->tmpFolder.'/controllers/index.js'));
+        $this->assertMatchesRegularExpression('#import hello from ["\']controllers/hello_controller["\']#', File::get($this->tmpFolder.'/controllers/index.js'));
+        $this->assertMatchesRegularExpression('#import { Controller } from ["\']@hotwired/stimulus["\']#', File::get($this->tmpFolder.'/controllers/hello_controller.js'));
+    }
+}

--- a/tests/PackagerSingleQuoteTest.php
+++ b/tests/PackagerSingleQuoteTest.php
@@ -15,8 +15,8 @@ class PackagerSingleQuoteTest extends TestCase
     {
         parent::setUp();
 
-        $this->singleQuoteFilePath = sys_get_temp_dir(). DIRECTORY_SEPARATOR . 'single-quote-importmap-'.Str::random(8).'.php';
-        file_put_contents($this->singleQuoteFilePath, file_get_contents(__DIR__. join(DIRECTORY_SEPARATOR, ['', 'fixtures', 'npm', 'single-quote-importmap.php'])));
+        $this->singleQuoteFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'single-quote-importmap-'.Str::random(8).'.php';
+        file_put_contents($this->singleQuoteFilePath, file_get_contents(__DIR__.implode(DIRECTORY_SEPARATOR, ['', 'fixtures', 'npm', 'single-quote-importmap.php'])));
         $this->packager = new Packager($this->singleQuoteFilePath);
     }
 

--- a/tests/stubs/fixing-paths/app.js
+++ b/tests/stubs/fixing-paths/app.js
@@ -1,0 +1,1 @@
+import './bootstrap'

--- a/tests/stubs/fixing-paths/bootstrap.js
+++ b/tests/stubs/fixing-paths/bootstrap.js
@@ -1,0 +1,3 @@
+import axios from 'axios';
+
+//

--- a/tests/stubs/fixing-paths/controllers/hello_controller.js
+++ b/tests/stubs/fixing-paths/controllers/hello_controller.js
@@ -1,0 +1,5 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+    //
+}

--- a/tests/stubs/fixing-paths/controllers/index.js
+++ b/tests/stubs/fixing-paths/controllers/index.js
@@ -1,0 +1,4 @@
+import { application } from '../libs/stimulus'
+import hello from './hello_controller'
+
+application.register('hello', hello)

--- a/tests/stubs/fixing-paths/libs/index.js
+++ b/tests/stubs/fixing-paths/libs/index.js
@@ -1,0 +1,2 @@
+import './turbo'
+import '../controllers'

--- a/tests/stubs/fixing-paths/libs/stimulus.js
+++ b/tests/stubs/fixing-paths/libs/stimulus.js
@@ -1,0 +1,9 @@
+import { Application } from '@hotwired/stimulus'
+
+const application = Application.start()
+
+// Configure Stimulus development experience
+application.debug = false
+window.Stimulus   = application
+
+export { application }

--- a/tests/stubs/fixing-paths/libs/turbo.js
+++ b/tests/stubs/fixing-paths/libs/turbo.js
@@ -1,0 +1,3 @@
+import * as Turbo from '@hotwired/turbo'
+
+export default Turbo

--- a/tests/tmp/.gitignore
+++ b/tests/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
### Fixed

- Fixes installation script not properly fixing the relative paths to something Importmap Laravel understand (relative to the `resources/js` folder)

---

closes https://github.com/tonysm/importmap-laravel/issues/17