### PR TITLE
Bump shims version to 1.8.2

### DIFF
--- a/config/importmap.php
+++ b/config/importmap.php
@@ -23,7 +23,7 @@ return [
      | since you may bump the shim version without having to upgrade.
      |
      */
-    'shim_version' => env('IMPORTMAP_SHIM_VERSION', '1.7.2'),
+    'shim_version' => env('IMPORTMAP_SHIM_VERSION', '1.8.2'),
 
     /*
      |------------------------------------------------------------------


### PR DESCRIPTION
### Changed

- Bumps `es-module-shims` to version 1.8.2