### PR TITLE
Dont optimize with URL

### DIFF
--- a/src/Commands/OptimizeCommand.php
+++ b/src/Commands/OptimizeCommand.php
@@ -49,7 +49,7 @@ class OptimizeCommand extends Command
                 ->map(function (string $oldFilename, string $module) use ($preloadModulePaths, $optimizedImports) {
                     return [
                         'module' => $module,
-                        'path' => isset($optimizedImports[$module]) ? asset($optimizedImports[$module]) : $oldFilename,
+                        'path' => $optimizedImports[$module] ?? $oldFilename,
                         'preload' => in_array($oldFilename, $preloadModulePaths),
                     ];
                 })

--- a/src/Importmap.php
+++ b/src/Importmap.php
@@ -33,7 +33,7 @@ class Importmap
     public function preloadedModulePaths(callable $assetResolver): array
     {
         if ($this->hasManifest()) {
-            return $this->resolvePreloadedModulesFromManifest();
+            return $this->resolvePreloadedModulesFromManifest($assetResolver);
         }
 
         return $this->resolveAssetPaths($this->expandPreloadingPackagesAndDirectories(), $assetResolver);
@@ -42,7 +42,7 @@ class Importmap
     public function asArray(callable $assetResolver): array
     {
         if ($this->hasManifest()) {
-            return $this->resolveImportsFromManifest();
+            return $this->resolveImportsFromManifest($assetResolver);
         }
 
         return [
@@ -70,19 +70,19 @@ class Importmap
         return Manifest::path();
     }
 
-    private function resolvePreloadedModulesFromManifest(): array
+    private function resolvePreloadedModulesFromManifest($assetResolver): array
     {
         return collect(json_decode(File::get($this->manifestPath()), true))
             ->filter(fn (array $json) => $json['preload'])
-            ->mapWithKeys(fn (array $json) => [$json['module'] => $json['path']])
+            ->mapWithKeys(fn (array $json) => [$json['module'] => $assetResolver($json['path'])])
             ->all();
     }
 
-    private function resolveImportsFromManifest(): array
+    private function resolveImportsFromManifest($assetResolver): array
     {
         return [
             'imports' => collect(json_decode(File::get($this->manifestPath()), true))
-                ->mapWithKeys(fn (array $json) => [$json['module'] => $json['path']])
+                ->mapWithKeys(fn (array $json) => [$json['module'] => $assetResolver($json['path'])])
                 ->all(),
         ];
     }


### PR DESCRIPTION
### Changed

- The `importmap:optimize` command must not set the URL in the file but instead resolve it at runtime when generating the assets. In a containerized environment, this will allow running the optimize command in a build step (where the `ASSET_URL` isn't set) instead of at runtime (usually at the entry point script)

---


closes #36 