### PR TITLE
Fix:  Prevent Type Error: Unsupported operand types: null + array

### DIFF
--- a/src/ImportmapLaravelServiceProvider.php
+++ b/src/ImportmapLaravelServiceProvider.php
@@ -46,7 +46,7 @@ class ImportmapLaravelServiceProvider extends PackageServiceProvider
         }
 
         if (app()->environment('local') && app()->runningInConsole()) {
-            config()->set('filesystems.links', config('filesystems.links') + [
+            config()->set('filesystems.links', config('filesystems.links', []) + [
                 public_path('js') => resource_path('js'),
             ]);
         }


### PR DESCRIPTION
Pass a blank array to config('filesystems.links') to avoid a Type error `Unsupported operand types: null + array` in the `packageBooted` method of `ImportmapLaravelServiceProvider` provider.