### PR TITLE
New `importmap:update` command and store CDN URL with package name and version in vendor comment

### DIFF
--- a/src/Commands/AuditCommand.php
+++ b/src/Commands/AuditCommand.php
@@ -4,9 +4,11 @@ namespace Tonysm\ImportmapLaravel\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Tonysm\ImportmapLaravel\Npm;
 use Tonysm\ImportmapLaravel\VulnerablePackage;
 
+#[AsCommand('importmap:audit')]
 class AuditCommand extends Command
 {
     public $signature = 'importmap:audit';

--- a/src/Commands/ClearCacheCommand.php
+++ b/src/Commands/ClearCacheCommand.php
@@ -4,9 +4,11 @@ namespace Tonysm\ImportmapLaravel\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Tonysm\ImportmapLaravel\Importmap;
 use Tonysm\ImportmapLaravel\Manifest;
 
+#[AsCommand('importmap:clear')]
 class ClearCacheCommand extends Command
 {
     public $signature = 'importmap:clear';

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -7,10 +7,12 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Terminal;
 use Tonysm\ImportmapLaravel\Actions\FixJsImportPaths;
 use Tonysm\ImportmapLaravel\Events\FailedToFixImportStatement;
 
+#[AsCommand('importmap:install')]
 class InstallCommand extends Command
 {
     public $signature = 'importmap:install';

--- a/src/Commands/JsonCommand.php
+++ b/src/Commands/JsonCommand.php
@@ -3,9 +3,11 @@
 namespace Tonysm\ImportmapLaravel\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Tonysm\ImportmapLaravel\AssetResolver;
 use Tonysm\ImportmapLaravel\Importmap;
 
+#[AsCommand('importmap:json')]
 class JsonCommand extends Command
 {
     public $signature = 'importmap:json';

--- a/src/Commands/OptimizeCommand.php
+++ b/src/Commands/OptimizeCommand.php
@@ -5,10 +5,12 @@ namespace Tonysm\ImportmapLaravel\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Tonysm\ImportmapLaravel\FileDigest;
 use Tonysm\ImportmapLaravel\Importmap;
 use Tonysm\ImportmapLaravel\Manifest;
 
+#[AsCommand('importmap:optimize')]
 class OptimizeCommand extends Command
 {
     public $signature = 'importmap:optimize';

--- a/src/Commands/OutdatedCommand.php
+++ b/src/Commands/OutdatedCommand.php
@@ -4,9 +4,11 @@ namespace Tonysm\ImportmapLaravel\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Tonysm\ImportmapLaravel\Npm;
 use Tonysm\ImportmapLaravel\OutdatedPackage;
 
+#[AsCommand('importmap:outdated')]
 class OutdatedCommand extends Command
 {
     public $signature = 'importmap:outdated';

--- a/src/Commands/PackagesCommand.php
+++ b/src/Commands/PackagesCommand.php
@@ -3,9 +3,11 @@
 namespace Tonysm\ImportmapLaravel\Commands;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Tonysm\ImportmapLaravel\Npm;
 use Tonysm\ImportmapLaravel\PackageVersion;
 
+#[AsCommand('importmap:packages')]
 class PackagesCommand extends Command
 {
     public $signature = 'importmap:packages';

--- a/src/Commands/PinCommand.php
+++ b/src/Commands/PinCommand.php
@@ -6,8 +6,10 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Tonysm\ImportmapLaravel\Packager;
 
+#[AsCommand('importmap:pin')]
 class PinCommand extends Command
 {
     /**

--- a/src/Commands/PinCommand.php
+++ b/src/Commands/PinCommand.php
@@ -84,7 +84,7 @@ class PinCommand extends Command
     private function pattern(string $package): string
     {
         return sprintf(
-            '#^Importmap::pin\("%s".*$#',
+            '#Importmap::pin\([\'\"]%s[\'\"].*$#',
             preg_quote($package),
         );
     }

--- a/src/Commands/UnpinCommand.php
+++ b/src/Commands/UnpinCommand.php
@@ -4,8 +4,10 @@ namespace Tonysm\ImportmapLaravel\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Tonysm\ImportmapLaravel\Packager;
 
+#[AsCommand('importmap:unpin')]
 class UnpinCommand extends Command
 {
     /**

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -25,8 +25,12 @@ class UpdateCommand extends Command
 
     public function handle(Npm $npm)
     {
-        $this->call('importmap:pin', [
-            'packages' => $npm->outdatedPackages()->pluck('name')->all(),
-        ]);
+        if (count($outdatedPackages = $npm->outdatedPackages()) > 0) {
+            $this->call('importmap:pin', [
+                'packages' => $outdatedPackages->pluck('name')->all(),
+            ]);
+        } else {
+            $this->components->info('No oudated packages found.');
+        }
     }
 }

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tonysm\ImportmapLaravel\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Tonysm\ImportmapLaravel\Npm;
+
+#[AsCommand('importmap:update')]
+class UpdateCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'importmap:update';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update outdated pinned packages.';
+
+    public function handle(Npm $npm)
+    {
+        $this->call('importmap:pin', [
+            'packages' => $npm->outdatedPackages()->pluck('name')->all(),
+        ]);
+    }
+}

--- a/src/ImportmapLaravelServiceProvider.php
+++ b/src/ImportmapLaravelServiceProvider.php
@@ -27,7 +27,8 @@ class ImportmapLaravelServiceProvider extends PackageServiceProvider
             ->hasCommand(Commands\UnpinCommand::class)
             ->hasCommand(Commands\OutdatedCommand::class)
             ->hasCommand(Commands\AuditCommand::class)
-            ->hasCommand(Commands\PackagesCommand::class);
+            ->hasCommand(Commands\PackagesCommand::class)
+            ->hasCommand(Commands\UpdateCommand::class);
     }
 
     public function packageRegistered()

--- a/src/Npm.php
+++ b/src/Npm.php
@@ -95,7 +95,7 @@ class Npm
 
     private function findPackagesFromLocalMatches(string $content)
     {
-        preg_match_all('/^Importmap::pin\(["\']([^"\']*)["\'].*\)\; \/\/.*@(\d+\.\d+\.\d+(?:[^\s]*)).*\r?$/m', $content, $matches);
+        preg_match_all('/^Importmap::pin\(.+\)\;\s*\/\/\s*(.+?)@(.+?)\s+.*\r?$/m', $content, $matches);
 
         if (count($matches) !== 3) {
             return collect();

--- a/src/Packager.php
+++ b/src/Packager.php
@@ -28,7 +28,7 @@ class Packager
             'install' => $packages,
             'flattenScope' => true,
             'env' => ['browser', 'module', $env],
-            'provider' => $from,
+            'provider' => $this->normalizeProvider($from),
         ]);
 
         return match ($response->status()) {
@@ -139,5 +139,13 @@ class Packager
         }
 
         throw Exceptions\ImportmapException::withUnexpectedResponseCode($response->status());
+    }
+
+    private function normalizeProvider(string $provider): string
+    {
+        return match ($provider) {
+            'jspm' => 'jspm.io',
+            default => $provider,
+        };
     }
 }

--- a/src/Packager.php
+++ b/src/Packager.php
@@ -55,10 +55,12 @@ class Packager
         $version = $this->extractPackageVersionFrom($url);
 
         return sprintf(
-            'Importmap::pin("%s", to: "%s"); // %s',
+            'Importmap::pin("%s", to: "%s"); // %s%s downloaded from %s',
             $package,
             Str::after($this->vendoredPackageName($package), 'resources'),
+            $package,
             $version,
+            $url,
         );
     }
 

--- a/tests/fixtures/npm/audit-importmap.php
+++ b/tests/fixtures/npm/audit-importmap.php
@@ -3,4 +3,4 @@
 use Tonysm\ImportmapLaravel\Facades\Importmap;
 
 Importmap::pin('is-svg', to: 'https://cdn.skypack.dev/is-svg@3.0.0', preload: true);
-Importmap::pin('lodash', to: '/js/vendor/lodash.js'); // @4.17.12
+Importmap::pin('lodash', to: '/js/vendor/lodash.js'); // lodash@4.17.12

--- a/tests/fixtures/npm/outdated-importmap.php
+++ b/tests/fixtures/npm/outdated-importmap.php
@@ -3,4 +3,4 @@
 use Tonysm\ImportmapLaravel\Facades\Importmap;
 
 Importmap::pin('is-svg', to: 'https://cdn.skypack.dev/is-svg@3.0.0', preload: true);
-Importmap::pin('lodash', to: '/js/vendor/lodash.js'); // @4.0.0
+Importmap::pin('lodash', to: '/js/vendor/lodash.js'); // lodash@4.0.0


### PR DESCRIPTION
### Added

- Adds a new `importmap:update` command that re-pins all packages to the latest version.

### Changed

- Store the package name, version, and CDN URL in the vendor package version comment
- Adds `.io` to JSPM URL
- [internal] Adds `AsCommand` attribute to all commands