### PR TITLE
Fix outdated command breaks on previous comment format

### DIFF
--- a/src/Commands/PinCommand.php
+++ b/src/Commands/PinCommand.php
@@ -84,7 +84,7 @@ class PinCommand extends Command
     private function pattern(string $package): string
     {
         return sprintf(
-            '#Importmap::pin\([\'\"]%s[\'\"].*$#',
+            '#.*pin\([\'\"]%s[\'\"].*#',
             preg_quote($package),
         );
     }

--- a/src/Npm.php
+++ b/src/Npm.php
@@ -95,7 +95,7 @@ class Npm
 
     private function findPackagesFromLocalMatches(string $content)
     {
-        preg_match_all('/^Importmap::pin\(.+\)\;\s*\/\/\s*(.+?)@(.+?)\s+.*\r?$/m', $content, $matches);
+        preg_match_all('/^Importmap::pin\([\'\"](.+?)[\'\"].*\)\;\s*\/\/\s*.*@(.+?)\s+.*\r?$/m', $content, $matches);
 
         if (count($matches) !== 3) {
             return collect();

--- a/src/Npm.php
+++ b/src/Npm.php
@@ -95,7 +95,7 @@ class Npm
 
     private function findPackagesFromLocalMatches(string $content)
     {
-        preg_match_all('/^Importmap::pin\([\'\"](.+?)[\'\"].*\)\;\s*\/\/\s*[@.]*@(\d+\.\d+\.\d+.*?)\s+.*\r?$/m', $content, $matches);
+        preg_match_all('/pin\([\'\"](.*?)[\'\"].*\);\s+\/\/\s+.*?@(\d+\.\d+\.\d+.*?)\s/m', $content, $matches);
 
         if (count($matches) !== 3) {
             return collect();

--- a/src/Npm.php
+++ b/src/Npm.php
@@ -95,7 +95,7 @@ class Npm
 
     private function findPackagesFromLocalMatches(string $content)
     {
-        preg_match_all('/^Importmap::pin\([\'\"](.+?)[\'\"].*\)\;\s*\/\/\s*.*@(.+?)\s+.*\r?$/m', $content, $matches);
+        preg_match_all('/^Importmap::pin\([\'\"](.+?)[\'\"].*\)\;\s*\/\/\s*.*@(\d+\.\d+\.\d+.*?)\s+.*\r?$/m', $content, $matches);
 
         if (count($matches) !== 3) {
             return collect();

--- a/src/Npm.php
+++ b/src/Npm.php
@@ -95,7 +95,7 @@ class Npm
 
     private function findPackagesFromLocalMatches(string $content)
     {
-        preg_match_all('/^Importmap::pin\([\'\"](.+?)[\'\"].*\)\;\s*\/\/\s*.*@(\d+\.\d+\.\d+.*?)\s+.*\r?$/m', $content, $matches);
+        preg_match_all('/^Importmap::pin\([\'\"](.+?)[\'\"].*\)\;\s*\/\/\s*[@.]*@(\d+\.\d+\.\d+.*?)\s+.*\r?$/m', $content, $matches);
 
         if (count($matches) !== 3) {
             return collect();

--- a/src/Packager.php
+++ b/src/Packager.php
@@ -123,7 +123,7 @@ class Packager
 
     private function extractPackageVersionFrom(string $url): string
     {
-        preg_match('#(@\d+\.\d+\.\d+)/#', $url, $matches);
+        preg_match('#(@\d+\.\d+\.\d+.*?)/#', $url, $matches);
 
         if (! ($matches[1] ?? false)) {
             return 'Unknown Version';

--- a/tests/fixtures/npm/audit-importmap.php
+++ b/tests/fixtures/npm/audit-importmap.php
@@ -3,4 +3,4 @@
 use Tonysm\ImportmapLaravel\Facades\Importmap;
 
 Importmap::pin('is-svg', to: 'https://cdn.skypack.dev/is-svg@3.0.0', preload: true);
-Importmap::pin('lodash', to: '/js/vendor/lodash.js'); // lodash@4.17.12
+Importmap::pin('lodash', to: '/js/vendor/lodash.js'); // @4.17.12

--- a/tests/fixtures/npm/outdated-importmap.php
+++ b/tests/fixtures/npm/outdated-importmap.php
@@ -3,4 +3,4 @@
 use Tonysm\ImportmapLaravel\Facades\Importmap;
 
 Importmap::pin('is-svg', to: 'https://cdn.skypack.dev/is-svg@3.0.0', preload: true);
-Importmap::pin('lodash', to: '/js/vendor/lodash.js'); // lodash@4.0.0
+Importmap::pin('lodash', to: '/js/vendor/lodash.js'); // @4.0.0


### PR DESCRIPTION
### Fixed

- Use the package name in the pin first argument instead of the new format (so it works on previous installs)